### PR TITLE
Add support for @data variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,96 @@ And now we can use the helper like this:
 
 ---
 
+## Data Variables for #each
+
+In Handlebars JS v1.1, data variables `@first` and `@last` were added for the #each helper. Due to the these variables
+not being backwards compatible, these data variables are disabled by default and must be enabled manually.
+
+To enable the new data variables, set the `enableDataVariables` option to `true` when instantiating the Handlebars
+instance.
+
+```php
+$handlebars = new Handlebars([
+    "loader" => $partialsLoader,
+    "partials_loader" => $partialsLoader,
+    "enableDataVariables" => true
+]);
+``` 
+
+Given the following template and data:
+```
+{{#each data}}{{#if @first}}FIRST: {{/if}}{{this}}<br>{{/each}}
+```
+```php
+'data' => ['apple', 'banana', 'carrot', 'zucchini']
+```
+The output will be
+```html
+FIRST: apple<br>banana<br>carrot<br>zucchini<br>
+```
+
+Given the following template and the data above:
+```
+{{#each data}}{{@first}}: {{this}}<br>{{/each}}
+```
+The output will be
+```html
+true: apple<br>banana<br>carrot<br>zucchini<br>
+```
+
+Data variables also support relative referencing within multiple #each statements.
+Given
+```
+{{#each data}}{{#each this}}outer: {{@../first}},inner: {{@first}};{{/each}}{{/each}}
+```
+```php
+'data' => [['apple', 'banana'], ['carrot', 'zucchini']]
+```
+The output will be 
+```
+outer: true,inner: true;outer: true,inner: false;outer: false,inner: true;outer: false,inner: false;
+```
+
+Be aware that when data variables are enabled, variables starting with `@` are considered restricted and will override
+values specified in the data.
+
+For example, given the following template and the following data, the output will be different depending on if data
+variables are enabled.
+
+```
+{{#each objects}}{{@first}}, {{@last}}, {{@index}}, {{@unknown}}{{/each}}
+```
+
+```php
+$object = new stdClass;
+$object->{'@first'} = 'apple';
+$object->{'@last'} = 'banana';
+$object->{'@index'} = 'carrot';
+$object->{'@unknown'} = 'zucchini';
+$data = ['objects' => [$object]];
+
+$engine = new \Handlebars\Handlebars(array(
+    'loader' => new \Handlebars\Loader\StringLoader(),
+    'helpers' => new \Handlebars\Helpers(),
+    'enableDataVariables'=> $enabled,
+));
+$engine->render($template, $data)
+``` 
+
+When `enableDataVariables` is `false`, existing behavior is not changed where some variables will be return. 
+
+```
+apple, banana, 0, zucchini
+```
+
+
+When `enableDataVariables` is `true`, the behavior matches HandlebarsJS 1.1 behavior, where all data variables replace
+variables defined in the data and any data variable prefixed with `@` that is unknown will be blank.
+
+```
+true, true, 0,
+```
+
 
 #### Credits
 

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
     "require": {
         "php": ">=5.4.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4"
+    },
     "autoload": {
         "psr-0": {
             "Handlebars": "src/"

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -92,6 +92,9 @@ class Context
      */
     public function pushData($data)
     {
+        if (!$this->enableDataVariables) {
+            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+        }
         array_push($this->dataStack, $data);
     }
 
@@ -134,6 +137,9 @@ class Context
      */
     public function popData()
     {
+        if (!$this->enableDataVariables) {
+            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+        }
         return array_pop($this->dataStack);
     }
 

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -22,6 +22,10 @@ use LogicException;
 
 class Context
 {
+    const DATA_KEY = 'key';
+    const DATA_INDEX = 'index';
+    const DATA_FIRST = 'first';
+    const DATA_LAST = 'last';
 
     /**
      * @var array stack for context only top stack is available
@@ -61,13 +65,13 @@ class Context
             $this->stack = [$context];
         }
 
-        if (isset($options['enableDataVariables'])) {
-            if (!is_bool($options['enableDataVariables'])) {
+        if (isset($options[Handlebars::OPTION_ENABLE_DATA_VARIABLES])) {
+            if (!is_bool($options[Handlebars::OPTION_ENABLE_DATA_VARIABLES])) {
                 throw new InvalidArgumentException(
-                    'Context Constructor "enableDataVariables" option must be a boolean'
+                    'Context Constructor "' . Handlebars::OPTION_ENABLE_DATA_VARIABLES . '" option must be a boolean'
                 );
             }
-            $this->enableDataVariables = $options['enableDataVariables'];
+            $this->enableDataVariables = $options[Handlebars::OPTION_ENABLE_DATA_VARIABLES];
         }
     }
 
@@ -102,7 +106,7 @@ class Context
     public function pushData($data)
     {
         if (!$this->enableDataVariables) {
-            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+            throw new LogicException('Data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
         }
         array_push($this->dataStack, $data);
     }
@@ -147,7 +151,7 @@ class Context
     public function popData()
     {
         if (!$this->enableDataVariables) {
-            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+            throw new LogicException('Data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
         }
         return array_pop($this->dataStack);
     }
@@ -279,7 +283,7 @@ class Context
     public function getDataVariable($variableName, $strict = false)
     {
         if (!$this->enableDataVariables) {
-            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+            throw new LogicException('Data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
         }
 
 
@@ -289,7 +293,7 @@ class Context
         if (substr($variableName, 0, 1) != '@') {
             if ($strict) {
                 throw new InvalidArgumentException(
-                    'can not find variable in context'
+                    'Can not find variable in context'
                 );
             }
             return '';
@@ -309,7 +313,7 @@ class Context
         if (count($this->dataStack) < $level) {
             if ($strict) {
                 throw new InvalidArgumentException(
-                    'can not find variable in context'
+                    'Can not find variable in context'
                 );
             }
 
@@ -329,7 +333,7 @@ class Context
         if (!array_key_exists($variableName, $current)) {
             if ($strict) {
                 throw new InvalidArgumentException(
-                    'can not find variable in context'
+                    'Can not find variable in context'
                 );
             }
 

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -18,6 +18,7 @@
 namespace Handlebars;
 
 use InvalidArgumentException;
+use LogicException;
 
 class Context
 {
@@ -43,15 +44,22 @@ class Context
     protected $key = [];
 
     /**
+     * @var bool enableDataVariables true if @data variables should be used.
+     */
+    protected $enableDataVariables;
+
+    /**
      * Mustache rendering Context constructor.
      *
      * @param mixed $context Default rendering context (default: null)
+     * @param bool $enableDataVariables Enables data variables (default: false)
      */
-    public function __construct($context = null)
+    public function __construct($context = null, $enableDataVariables = false)
     {
         if ($context !== null) {
             $this->stack = [$context];
         }
+        $this->enableDataVariables = $enableDataVariables;
     }
 
     /**
@@ -150,6 +158,26 @@ class Context
     }
 
     /**
+     * Get the index of current section item.
+     *
+     * @return mixed Last index
+     */
+    public function lastIndex()
+    {
+        return end($this->index);
+    }
+
+    /**
+     * Get the key of current object property.
+     *
+     * @return mixed Last key
+     */
+    public function lastKey()
+    {
+        return end($this->key);
+    }
+
+    /**
      * Change the current context to one of current context members
      *
      * @param string $variableName name of variable or a callable on current context
@@ -181,7 +209,7 @@ class Context
         $variableName = trim($variableName);
 
         //Handle data variables (@index, @first, @last, etc)
-        if (substr($variableName, 0, 1) == '@') {
+        if ($this->enableDataVariables && substr($variableName, 0, 1) == '@') {
             return $this->getDataVariable($variableName, $strict);
         }
 
@@ -235,6 +263,11 @@ class Context
      */
     public function getDataVariable($variableName, $strict = false)
     {
+        if (!$this->enableDataVariables) {
+            throw new LogicException('data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
+        }
+
+
         $variableName = trim($variableName);
 
         // make sure we get an at-symbol prefix

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -55,7 +55,7 @@ class Context
      * @param array $options Options for the context. It may contain the following: (default: empty array)
      *                       enableDataVariables => Boolean, Enables @data variables (default: false)
      */
-    public function __construct($context = null, array $options = [])
+    public function __construct($context = null, $options = [])
     {
         if ($context !== null) {
             $this->stack = [$context];

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -46,20 +46,29 @@ class Context
     /**
      * @var bool enableDataVariables true if @data variables should be used.
      */
-    protected $enableDataVariables;
+    protected $enableDataVariables = false;
 
     /**
      * Mustache rendering Context constructor.
      *
      * @param mixed $context Default rendering context (default: null)
-     * @param bool $enableDataVariables Enables data variables (default: false)
+     * @param array $options Options for the context. It may contain the following: (default: empty array)
+     *                       enableDataVariables => Boolean, Enables @data variables (default: false)
      */
-    public function __construct($context = null, $enableDataVariables = false)
+    public function __construct($context = null, array $options = [])
     {
         if ($context !== null) {
             $this->stack = [$context];
         }
-        $this->enableDataVariables = $enableDataVariables;
+
+        if (isset($options['enableDataVariables'])) {
+            if (!is_bool($options['enableDataVariables'])) {
+                throw new InvalidArgumentException(
+                    'Context Constructor "enableDataVariables" option must be a boolean'
+                );
+            }
+            $this->enableDataVariables = $options['enableDataVariables'];
+        }
     }
 
     /**

--- a/src/Handlebars/Context.php
+++ b/src/Handlebars/Context.php
@@ -58,6 +58,8 @@ class Context
      * @param mixed $context Default rendering context (default: null)
      * @param array $options Options for the context. It may contain the following: (default: empty array)
      *                       enableDataVariables => Boolean, Enables @data variables (default: false)
+     *
+     * @throws InvalidArgumentException when calling this method when enableDataVariables is not a boolean.
      */
     public function __construct($context = null, $options = [])
     {
@@ -102,6 +104,7 @@ class Context
     /**
      * Pushes data variables onto the stack. This is used to support @data variables.
      * @param array $data Associative array where key is the name of the @data variable and value is the value.
+     * @throws LogicException when calling this method without having enableDataVariables.
      */
     public function pushData($data)
     {
@@ -147,6 +150,7 @@ class Context
      * Pop the last section data from the stack.
      *
      * @return array Last data
+     * @throws LogicException when calling this method without having enableDataVariables.
      */
     public function popData()
     {
@@ -279,13 +283,13 @@ class Context
      * @param $variableName
      * @param bool $strict
      * @return mixed
+     * @throws LogicException when calling this method without having enableDataVariables.
      */
     public function getDataVariable($variableName, $strict = false)
     {
         if (!$this->enableDataVariables) {
             throw new LogicException('Data variables are not supported due to the enableDataVariables configuration. Remove the call to data variables or change the setting.');
         }
-
 
         $variableName = trim($variableName);
 

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -25,6 +25,8 @@ class Handlebars
     private static $instance = null;
     const VERSION = '2.2';
 
+    const OPTION_ENABLE_DATA_VARIABLES = 'enableDataVariables';
+
     /**
      * factory method
      *
@@ -146,13 +148,13 @@ class Handlebars
             $this->aliases = $options['partials_alias'];
         }
 
-        if (isset($options['enableDataVariables'])) {
-            if (!is_bool($options['enableDataVariables'])) {
+        if (isset($options[self::OPTION_ENABLE_DATA_VARIABLES])) {
+            if (!is_bool($options[self::OPTION_ENABLE_DATA_VARIABLES])) {
                 throw new InvalidArgumentException(
-                    'Handlebars Constructor "enableDataVariables" option must be a boolean'
+                    'Handlebars Constructor "' . self::OPTION_ENABLE_DATA_VARIABLES . '" option must be a boolean'
                 );
             }
-            $this->enableDataVariables = $options['enableDataVariables'];
+            $this->enableDataVariables = $options[self::OPTION_ENABLE_DATA_VARIABLES];
         }
     }
 

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -87,6 +87,11 @@ class Handlebars
     private $aliases = array();
 
     /**
+     * @var bool Enable @data variables
+     */
+    private $enableDataVariables = false;
+
+    /**
      * Handlebars engine constructor
      * $options array can contain :
      * helpers        => Helpers object
@@ -138,6 +143,15 @@ class Handlebars
             && is_array($options['partials_alias'])
         ) {
             $this->aliases = $options['partials_alias'];
+        }
+
+        if (isset($options['enableDataVariables'])) {
+            if (!is_bool($options['enableDataVariables'])) {
+                throw new InvalidArgumentException(
+                    'Handlebars Constructor "enableDataVariables" option must be a boolean'
+                );
+            }
+            $this->enableDataVariables = $options['enableDataVariables'];
         }
     }
 
@@ -416,6 +430,15 @@ class Handlebars
             $this->parser = new Parser();
         }
         return $this->parser;
+    }
+
+    /**
+     * Determines if the @data variables are enabled.
+     * @return bool
+     */
+    public function isDataVariablesEnabled()
+    {
+        return $this->enableDataVariables;
     }
 
     /**

--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -100,6 +100,7 @@ class Handlebars
      * loader         => Loader object
      * partials_loader => Loader object
      * cache          => Cache object
+     * enableDataVariables => boolean. Enables @data variables (default: false)
      *
      * @param array $options array of options to set
      *

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -273,17 +273,25 @@ class Helpers
                     $tpl = clone $template;
                     if ($islist) {
                         $context->pushIndex($key);
-                        $context->pushData([
-                            'key' => $key,
-                            'index' => $key,
-                            'last' => $key == ($itemCount - 1),
-                            'first' => $key == 0,
-                        ]);
+
+                        // If data variables are enabled, push the data related to this #each context
+                        if ($template->getEngine()->isDataVariablesEnabled()) {
+                            $context->pushData([
+                                'key' => $key,
+                                'index' => $key,
+                                'last' => $key == ($itemCount - 1),
+                                'first' => $key == 0,
+                            ]);
+                        }
                     } else {
                         $context->pushKey($key);
-                        $context->pushData([
-                            'key' => $key,
-                        ]);
+
+                        // If data variables are enabled, push the data related to this #each context
+                        if ($template->getEngine()->isDataVariablesEnabled()) {
+                            $context->pushData([
+                                'key' => $key,
+                            ]);
+                        }
                     }
                     $context->push($var);
                     $tpl->setStopToken('else');
@@ -294,7 +302,10 @@ class Helpers
                     } else {
                         $context->popKey();
                     }
-                    $context->popData();
+
+                    if ($template->getEngine()->isDataVariablesEnabled()) {
+                        $context->popData();
+                    }
                 }
                 return $buffer;
             }

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -263,12 +263,27 @@ class Helpers
             if (is_array($tmp) && ! count($tmp)) {
                 return $this->renderElse($template, $context);
             } else {
+
+                $itemCount = -1;
+                if ($islist) {
+                    $itemCount = count($tmp);
+                }
+
                 foreach ($tmp as $key => $var) {
                     $tpl = clone $template;
                     if ($islist) {
                         $context->pushIndex($key);
+                        $context->pushData([
+                            'key' => $key,
+                            'index' => $key,
+                            'last' => $key == ($itemCount - 1),
+                            'first' => $key == 0,
+                        ]);
                     } else {
                         $context->pushKey($key);
+                        $context->pushData([
+                            'key' => $key,
+                        ]);
                     }
                     $context->push($var);
                     $tpl->setStopToken('else');
@@ -279,6 +294,7 @@ class Helpers
                     } else {
                         $context->popKey();
                     }
+                    $context->popData();
                 }
                 return $buffer;
             }

--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -277,10 +277,10 @@ class Helpers
                         // If data variables are enabled, push the data related to this #each context
                         if ($template->getEngine()->isDataVariablesEnabled()) {
                             $context->pushData([
-                                'key' => $key,
-                                'index' => $key,
-                                'last' => $key == ($itemCount - 1),
-                                'first' => $key == 0,
+                                Context::DATA_KEY => $key,
+                                Context::DATA_INDEX => $key,
+                                Context::DATA_LAST => $key == ($itemCount - 1),
+                                Context::DATA_FIRST => $key == 0,
                             ]);
                         }
                     } else {
@@ -289,7 +289,7 @@ class Helpers
                         // If data variables are enabled, push the data related to this #each context
                         if ($template->getEngine()->isDataVariablesEnabled()) {
                             $context->pushData([
-                                'key' => $key,
+                                Context::DATA_KEY => $key,
                             ]);
                         }
                     }

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -344,11 +344,13 @@ class Template
     {
         $name = $current[Tokenizer::NAME];
         $value = $context->get($name);
-        if ($name == '@index') {
-            return $context->lastIndex();
-        }
-        if ($name == '@key') {
-            return $context->lastKey();
+
+        if (substr(trim($name), 0, 1) == '@') {
+            $variable = $context->getDataVariable($name);
+            if (is_bool($variable)) {
+                return $variable ? 'true' : 'false';
+            }
+            return $variable;
         }
         if ($escaped) {
             $args = $this->handlebars->getEscapeArgs();

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -122,7 +122,9 @@ class Template
     public function render($context)
     {
         if (!$context instanceof Context) {
-            $context = new Context($context, $this->handlebars->isDataVariablesEnabled());
+            $context = new Context($context, [
+                'enableDataVariables' => $this->handlebars->isDataVariablesEnabled(),
+            ]);
         }
         $topTree = end($this->stack); // never pop a value from stack
         list($index, $tree, $stop) = $topTree;

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -122,7 +122,7 @@ class Template
     public function render($context)
     {
         if (!$context instanceof Context) {
-            $context = new Context($context);
+            $context = new Context($context, $this->handlebars->isDataVariablesEnabled());
         }
         $topTree = end($this->stack); // never pop a value from stack
         list($index, $tree, $stop) = $topTree;
@@ -345,13 +345,26 @@ class Template
         $name = $current[Tokenizer::NAME];
         $value = $context->get($name);
 
-        if (substr(trim($name), 0, 1) == '@') {
-            $variable = $context->getDataVariable($name);
-            if (is_bool($variable)) {
-                return $variable ? 'true' : 'false';
+        // If @data variables are enabled, use the more complex algorithm for handling the the variables otherwise
+        // use the previous version.
+        if ($this->handlebars->isDataVariablesEnabled()) {
+            if (substr(trim($name), 0, 1) == '@') {
+                $variable = $context->getDataVariable($name);
+                if (is_bool($variable)) {
+                    return $variable ? 'true' : 'false';
+                }
+                return $variable;
             }
-            return $variable;
+        } else {
+            // If @data variables are not enabled, then revert back to legacy behavior
+            if ($name == '@index') {
+                return $context->lastIndex();
+            }
+            if ($name == '@key') {
+                return $context->lastKey();
+            }
         }
+
         if ($escaped) {
             $args = $this->handlebars->getEscapeArgs();
             array_unshift($args, $value);

--- a/tests/Handlebars/HandlebarsTest.php
+++ b/tests/Handlebars/HandlebarsTest.php
@@ -234,6 +234,24 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($result, $engine->render($src, $data));
     }
 
+    public function testDataVariables1()
+    {
+        $object = new stdClass;
+        $object->{'@first'} = 'apple';
+        $object->{'@last'} = 'banana';
+        $object->{'@index'} = 'carrot';
+        $object->{'@unknown'} = 'zucchini';
+        $data = ['data' => [$object]];
+        $engine = new \Handlebars\Handlebars(array(
+            'loader' => new \Handlebars\Loader\StringLoader(),
+            'helpers' => new \Handlebars\Helpers(),
+            'enableDataVariables'=> false,
+        ));
+        $template = "{{#each data}}{{@first}}, {{@last}}, {{@index}}, {{@unknown}}{{/each}}";
+
+        $this->assertEquals("", $engine->render($template, $data));
+    }
+
     /**
      * Data provider for data variables
      * @return array

--- a/tests/Handlebars/HandlebarsTest.php
+++ b/tests/Handlebars/HandlebarsTest.php
@@ -132,6 +132,51 @@ class HandlebarsTest extends \PHPUnit_Framework_TestCase
                 '23'
             ],
             [
+                '{{#each data}}{{@index}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                '0123'
+            ],
+            [
+                '{{#each data}}{{@key}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                '0123'
+            ],
+            [
+                '{{#each data}}{{#each this}}outer: {{@../key}},inner: {{@key}};{{/each}}{{/each}}',
+                ['data' => [['apple', 'banana'], ['carrot', 'zucchini']]],
+                'outer: 0,inner: 0;outer: 0,inner: 1;outer: 1,inner: 0;outer: 1,inner: 1;'
+            ],
+            [
+                '{{#each data}}{{#if @first}}true{{else}}false{{/if}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                'truefalsefalsefalse'
+            ],
+            [
+                '{{#each data}}{{@first}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                'truefalsefalsefalse'
+            ],
+            [
+                '{{#each data}}{{#each this}}outer: {{@../first}},inner: {{@first}};{{/each}}{{/each}}',
+                ['data' => [['apple', 'banana'], ['carrot', 'zucchini']]],
+                'outer: true,inner: true;outer: true,inner: false;outer: false,inner: true;outer: false,inner: false;'
+            ],
+            [
+                '{{#each data}}{{#if @last}}true{{else}}false{{/if}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                'falsefalsefalsetrue'
+            ],
+            [
+                '{{#each data}}{{@last}}{{/each}}',
+                ['data' => ['apple', 'banana', 'carrot', 'zucchini']],
+                'falsefalsefalsetrue'
+            ],
+            [
+                '{{#each data}}{{#each this}}outer: {{@../last}},inner: {{@last}};{{/each}}{{/each}}',
+                ['data' => [['apple', 'banana'], ['carrot', 'zucchini']]],
+                'outer: false,inner: false;outer: false,inner: true;outer: true,inner: false;outer: true,inner: true;'
+            ],
+            [
                 '{{#upper data}}',
                 ['data' => "hello"],
                 'HELLO'


### PR DESCRIPTION
This PR adds support for data variables `@first`, `@last`, `@index` and `@key` within #each (outlined in the [latest documentation](https://handlebarsjs.com/api-reference/data-variables.html)). These data variables can be used as variables or within the template directly. 

Given the following template and data:
```
{{#each data}}{{#if @first}}FIRST: {{/if}}{{this}}<br>{{/each}}
```
```php
'data' => ['apple', 'banana', 'carrot', 'zucchini']
```
The output will be
```html
FIRST: apple<br>banana<br>carrot<br>zucchini<br>
```

Given the following template and the data above:
```
{{#each data}}{{@first}}: {{this}}<br>{{/each}}
```
The output will be
```html
true: apple<br>banana<br>carrot<br>zucchini<br>
```

Data variables also support relative referencing within multiple #each statements.
Given
```
{{#each data}}{{#each this}}outer: {{@../first}},inner: {{@first}};{{/each}}{{/each}}
```
```php
'data' => [['apple', 'banana'], ['carrot', 'zucchini']]
```
The output will be 
```
outer: true,inner: true;outer: true,inner: false;outer: false,inner: true;outer: false,inner: false;
```

See the attached tests for more scenarios.
