### PR TITLE
Add support for whitespace control (~)

### DIFF
--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -26,6 +26,7 @@ class Handlebars
     const VERSION = '2.2';
 
     const OPTION_ENABLE_DATA_VARIABLES = 'enableDataVariables';
+    const OPTION_ENABLE_WHITESPACE_CONTROL = 'enableWhitespaceControl';
 
     /**
      * factory method
@@ -94,6 +95,11 @@ class Handlebars
     private $enableDataVariables = false;
 
     /**
+     * @var bool Enable "~" to strip whitespace before and after tags
+     */
+    private $enableWhitespaceControl = false;
+
+    /**
      * Handlebars engine constructor
      * $options array can contain :
      * helpers        => Helpers object
@@ -103,6 +109,7 @@ class Handlebars
      * partials_loader => Loader object
      * cache          => Cache object
      * enableDataVariables => boolean. Enables @data variables (default: false)
+     * enableWhitespaceControl => boolean. Enables whitespace control using "~" within tags. (default: false)
      *
      * @param array $options array of options to set
      *
@@ -155,6 +162,15 @@ class Handlebars
                 );
             }
             $this->enableDataVariables = $options[self::OPTION_ENABLE_DATA_VARIABLES];
+        }
+
+        if (isset($options[self::OPTION_ENABLE_WHITESPACE_CONTROL])) {
+            if (!is_bool($options[self::OPTION_ENABLE_WHITESPACE_CONTROL])) {
+                throw new InvalidArgumentException(
+                    'Handlebars Constructor "' . self::OPTION_ENABLE_WHITESPACE_CONTROL . '" option must be a boolean'
+                );
+            }
+            $this->enableWhitespaceControl = $options[self::OPTION_ENABLE_WHITESPACE_CONTROL];
         }
     }
 
@@ -442,6 +458,15 @@ class Handlebars
     public function isDataVariablesEnabled()
     {
         return $this->enableDataVariables;
+    }
+
+    /**
+     * Determines if whitespace control using "~" is enabled.
+     * @return bool
+     */
+    public function isWhitespaceControlEnabled()
+    {
+        return $this->enableWhitespaceControl;
     }
 
     /**

--- a/src/Handlebars/Parser.php
+++ b/src/Handlebars/Parser.php
@@ -71,6 +71,17 @@ class Parser
                             && isset($result[Tokenizer::NAME])
                             && $result[Tokenizer::NAME] == $token[Tokenizer::NAME]
                         ) {
+
+                            // $result is the open section
+                            // $token is the close section
+
+                            // We need to compact the whitespace control so that the single node represents both the
+                            // open and close nodes in the template.
+                            $openWhitespaceAfter = $result[Tokenizer::STRIP_WHITESPACE_AFTER];
+                            $result[Tokenizer::STRIP_WHITESPACE_AFTER] = $token[Tokenizer::STRIP_WHITESPACE_AFTER];
+                            $result[Tokenizer::STRIP_WHITESPACE_BEFORE_CONTENT] = $openWhitespaceAfter;
+                            $result[Tokenizer::STRIP_WHITESPACE_AFTER_CONTENT] = $token[Tokenizer::STRIP_WHITESPACE_BEFORE];
+
                             $result[Tokenizer::NODES] = $newNodes;
                             $result[Tokenizer::END] = $token[Tokenizer::INDEX];
                             array_push($stack, $result);

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -202,6 +202,18 @@ class Template
             case Tokenizer::T_UNESCAPED:
             case Tokenizer::T_UNESCAPED_2:
                 $newValue = $this->variables($context, $current, false);
+                if ($this->handlebars->isWhitespaceControlEnabled()) {
+                    if ($mustStripWhitespaceBefore || $this->isArrayValueTrue($current, Tokenizer::STRIP_WHITESPACE_BEFORE)) {
+                        $buffer = $this->stripTrailingWhitespace($buffer);
+                        $newValue = $this->stripLeadingWhitespace($newValue);
+                    }
+                    if ($this->isArrayValueTrue($current, Tokenizer::STRIP_WHITESPACE_AFTER_CONTENT)) {
+                        $newValue = $this->stripTrailingWhitespace($newValue);
+                    }
+
+                    // Make sure the next nodes to strip before
+                    $mustStripWhitespaceBefore = $this->isArrayValueTrue($current, Tokenizer::STRIP_WHITESPACE_AFTER);
+                }
                 $buffer .= $newValue;
                 break;
             case Tokenizer::T_ESCAPED:

--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -147,9 +147,13 @@ class Tokenizer
                     $i += $openingTagLength - 1;
 
                     // skip the whitespace control character
-                    if ($text[$i + 1] === self::T_WHITESPACE_CONTROL) {
+                    if (strlen($text) >= $i + 1 && $text[$i + 1] === self::T_WHITESPACE_CONTROL) {
                         $this->startsWithWhitespaceControl = true;
                         $i++;
+                    } else if (strlen($text) >= $i + 2 && $text[$i + 1] === self::T_UNESCAPED && $text[$i + 2] === self::T_WHITESPACE_CONTROL) {
+                        // handle {{{~foo}}} case
+                        $this->startsWithWhitespaceControl = true;
+                        $text = substr($text, 0, $i + 2) . substr($text, $i + 3);
                     }
 
                     if (isset($this->tagTypes[$text[$i + 1]])) {
@@ -204,7 +208,7 @@ class Tokenizer
 
                         // In order to keep backwards compatibility when whitespace control is not enabled, the original
                         // name of the variable must include the whitespace control characters (~).
-                        if ($this->tagType === self::T_ESCAPED) {
+                        if ($this->tagType === self::T_ESCAPED || $this->tagType === self::T_UNESCAPED) {
                             $originalName = $this->buffer;
                             if ($this->startsWithWhitespaceControl) {
                                 $originalName = self::T_WHITESPACE_CONTROL . $originalName;

--- a/tests/Handlebars/MapLoader.php
+++ b/tests/Handlebars/MapLoader.php
@@ -1,0 +1,29 @@
+<?php
+
+use Handlebars\Loader;
+
+/**
+ * Creates a loader backed by an associative array that maps the key of the map to the name used during the load. If
+ * the name does not exist in the map, an IllegalArgumentException is thrown.
+ */
+class MapLoader implements Loader
+{
+    private $values;
+
+    public function __construct($values)
+    {
+        if (!is_array($values)) {
+            throw new InvalidArgumentException('Unexpected value for values argument. Expected an array.');
+        }
+        $this->values = $values;
+    }
+
+    public function load($name)
+    {
+        if (isset($this->values[$name])) {
+            return $this->values[$name];
+        } else {
+            throw new InvalidArgumentException('Template ' . $name . ' not found.');
+        }
+    }
+}

--- a/tests/Handlebars/WhitespaceTest.php
+++ b/tests/Handlebars/WhitespaceTest.php
@@ -141,6 +141,21 @@ class WhitespaceTest extends PHPUnit_Framework_TestCase
                 'data' => ['foo' => 'bar', '~foo~' => '~bar~'],
                 'enabled' => 'barbar bar ',
                 'disabled' => ' ~bar~ bar bar '
+            ], [
+                'template' => ' {{{~foo~}}} ',
+                'data' => ['foo' => 'bar<', '~foo~' => '~bar<~'],
+                'enabled' => 'bar<',
+                'disabled' => ' ~bar<~ '
+            ], [
+                'template' => ' {{{~foo}}} ',
+                'data' => ['foo' => 'bar<', '~foo' => '~bar<'],
+                'enabled' => 'bar< ',
+                'disabled' => ' ~bar< '
+            ], [
+                'template' => ' {{{foo~}}} ',
+                'data' => ['foo' => 'bar<', 'foo~' => 'bar<~'],
+                'enabled' => ' bar<',
+                'disabled' => ' bar<~ '
             ]
         ];
 

--- a/tests/Handlebars/WhitespaceTest.php
+++ b/tests/Handlebars/WhitespaceTest.php
@@ -92,97 +92,17 @@ class WhitespaceTest extends PHPUnit_Framework_TestCase
                 'data' => $data,
                 'enabled' => ' abara ',
                 'disabled' => " a\n\n\nbar \n\n\na "
-            ], /* [
-                'template' => ' {{~^if foo~}} bar {{~/if~}} ',
-                'data' => $data,
-                'enabled' => 'bar',
-                'disabled' => '  bar  '
             ], [
-                'template' => ' {{^if foo~}} bar {{/if~}} ',
-                'data' => $data,
-                'enabled' => ' bar ',
-                'disabled' => '  bar  '
-            ], [
-                'template' => ' {{~^if foo}} bar {{~/if}} ',
-                'data' => $data,
-                'enabled' => ' bar ',
-                'disabled' => '  bar  '
-            ], [
-                'template' => ' {{^if foo}} bar {{/if}} ',
-                'data' => $data,
-                'enabled' => '  bar  ',
-                'disabled' => '  bar  '
-            ], [
-                'template' => " \n\n{{~^if foo~}} \n\nbar \n\n{{~/if~}}\n\n ",
-                'data' => $data,
-                'enabled' => 'bar',
-                'disabled' => " \n\n \n\nbar \n\n\n\n "
-            ], [
-                'template' => '{{#if foo~}} bar {{~^~}} baz {{~/if}}',
-                'data' => $data,
-                'enabled' => 'bar',
-                'disabled' => ' bar '
-            ], [
-                'template' => '{{#if foo~}} bar {{^~}} baz {{/if}}',
-                'data' => $data,
-                'enabled' => 'bar ',
-                'disabled' => ' bar '
-            ], [
-                'template' => '{{#if foo}} bar {{~^~}} baz {{~/if}}',
-                'data' => $data,
-                'enabled' => ' bar ',
-                'disabled' => ' bar '
-            ], [
-                'template' => '{{#if foo}} bar {{^~}} baz {{/if}}',
-                'data' => $data,
-                'enabled' => ' bar ',
-                'disabled' => ' bar '
-            ],*/ [
                 'template' => '{{#if foo~}} bar {{~else~}} baz {{~/if}}',
                 'data' => $data,
                 'enabled' => 'bar',
                 'disabled' => ' bar ~caz~ baz ' // {{~else~}} is evaluated as a variable
-            ], /* [
-                'template' => "\n\n{{~#if foo~}} \n\nbar \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
-                'data' => $data,
-                'enabled' => 'bar',
-                'disabled' => ' bar~ ~caz~ baz '
             ], [
-                'template' => "\n\n{{~#if foo~}} \n\n{{{foo}}} \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
-                'data' => $data,
-                'enabled' => 'bar',
-                'disabled' => ' bar~ ~caz~ baz '
-            ], [
-                'template' => '{{#if foo~}} bar {{~^~}} baz {{~/if}}',
-                'data' => [],
-                'enabled' => 'baz',
-                'disabled' => ' bar~ ~caz~ baz '
-            ], [
-                'template' => '{{#if foo}} bar {{~^~}} baz {{/if}}',
-                'data' => [],
-                'enabled' => 'baz ',
-                'disabled' => ' bar~ ~caz~ baz '
-            ], [
-                'template' => '{{#if foo~}} bar {{~^}} baz {{~/if}}',
-                'data' => [],
-                'enabled' => ' baz',
-                'disabled' => ' bar~ ~caz~ baz '
-            ], [
-                'template' => '{{#if foo~}} bar {{~^}} baz {{/if}}',
-                'data' => [],
-                'enabled' => ' baz ',
-                'disabled' => ' bar~ ~caz~ baz '
-            ],*/ [
                 'template' => '{{#if foo~}} bar {{~else~}} baz {{~/if}}',
                 'data' => [],
                 'enabled' => 'baz',
                 'disabled' => ''
-            ], /* [
-                'template' => "\n\n{{~#if foo~}} \n\nbar \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
-                'data' => [],
-                'enabled' => 'baz',
-                'disabled' => ''
-            ], */ [
+            ], [
                 'template' => 'foo {{~> dude~}} ',
                 'data' => [],
                 'partials' => [

--- a/tests/Handlebars/WhitespaceTest.php
+++ b/tests/Handlebars/WhitespaceTest.php
@@ -1,0 +1,258 @@
+<?php
+
+require_once 'MapLoader.php';
+
+use Handlebars\Handlebars;
+use Handlebars\Helpers;
+use Handlebars\Loader\StringLoader;
+
+class WhitespaceTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @param bool $enabled
+     * @param string $template
+     * @param array $data
+     * @param array $partials
+     * @param string $expected
+     * @dataProvider dataWhitespaceControl
+     */
+    public function testWhitespaceControl($enabled, $template, $data, $partials, $expected)
+    {
+        $helpers = new Helpers();
+        $engine = new Handlebars(array(
+            'loader' => new StringLoader(),
+            'partials_loader' => new MapLoader($partials),
+            'helpers' => $helpers,
+            'enableWhitespaceControl'=> $enabled,
+        ));
+
+        $this->assertEquals($expected, $engine->render($template, $data));
+    }
+
+    public function dataWhitespaceControl()
+    {
+        $data = [
+            'foo' => 'bar<',
+            '~foo~' => '~bar~',
+            '~foo' => '~bar',
+            'foo~' => 'bar~',
+            '~else~' => '~caz~',
+            '~else' => '~caz',
+            'else~' => 'caz~',
+        ];
+
+        $cases = [
+            [
+                'template' => ' {{foo}} ',
+                'data' => $data,
+                'enabled' => ' bar&lt; ',
+                'disabled' => ' bar&lt; ',
+            ], [
+                'template' => ' {{~foo~}} ',
+                'data' => $data,
+                'enabled' => 'bar&lt;',
+                'disabled' => ' ~bar~ ', // should grab the value out of the data
+            ], [
+                'template' => ' {{~foo}} ',
+                'data' => $data,
+                'enabled' => 'bar&lt; ',
+                'disabled' => ' ~bar ',
+            ], [
+                'template' => ' {{foo~}} ',
+                'data' => $data,
+                'enabled' => ' bar&lt;',
+                'disabled' => ' bar~ ',
+            ], [
+                'template' => ' {{~#if foo~}} bar {{~/if~}} ',
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => '  bar  '
+            ], [
+                'template' => ' {{#if foo~}} bar {{/if~}} ',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => '  bar  '
+            ], [
+                'template' => ' {{~#if foo}} bar {{~/if}} ',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => '  bar  '
+            ], [
+                'template' => '  {{#if foo}} bar {{/if}}  ',
+                'data' => $data,
+                'enabled' => '   bar   ',
+                'disabled' => '   bar   '
+            ], [
+                'template' => " \n\n{{~#if foo~}} \n\nbar \n\n{{~/if~}}\n\n ",
+                'data' => $data,
+                'enabled' => "bar",
+                'disabled' => " \n\n\nbar \n\n\n "
+            ], [
+                'template' => " a\n\n{{~#if foo~}} \n\nbar \n\n{{~/if~}}\n\na ",
+                'data' => $data,
+                'enabled' => ' abara ',
+                'disabled' => " a\n\n\nbar \n\n\na "
+            ], /* [
+                'template' => ' {{~^if foo~}} bar {{~/if~}} ',
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => '  bar  '
+            ], [
+                'template' => ' {{^if foo~}} bar {{/if~}} ',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => '  bar  '
+            ], [
+                'template' => ' {{~^if foo}} bar {{~/if}} ',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => '  bar  '
+            ], [
+                'template' => ' {{^if foo}} bar {{/if}} ',
+                'data' => $data,
+                'enabled' => '  bar  ',
+                'disabled' => '  bar  '
+            ], [
+                'template' => " \n\n{{~^if foo~}} \n\nbar \n\n{{~/if~}}\n\n ",
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => " \n\n \n\nbar \n\n\n\n "
+            ], [
+                'template' => '{{#if foo~}} bar {{~^~}} baz {{~/if}}',
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => ' bar '
+            ], [
+                'template' => '{{#if foo~}} bar {{^~}} baz {{/if}}',
+                'data' => $data,
+                'enabled' => 'bar ',
+                'disabled' => ' bar '
+            ], [
+                'template' => '{{#if foo}} bar {{~^~}} baz {{~/if}}',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => ' bar '
+            ], [
+                'template' => '{{#if foo}} bar {{^~}} baz {{/if}}',
+                'data' => $data,
+                'enabled' => ' bar ',
+                'disabled' => ' bar '
+            ],*/ [
+                'template' => '{{#if foo~}} bar {{~else~}} baz {{~/if}}',
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => ' bar ~caz~ baz ' // {{~else~}} is evaluated as a variable
+            ], /* [
+                'template' => "\n\n{{~#if foo~}} \n\nbar \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => ' bar~ ~caz~ baz '
+            ], [
+                'template' => "\n\n{{~#if foo~}} \n\n{{{foo}}} \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
+                'data' => $data,
+                'enabled' => 'bar',
+                'disabled' => ' bar~ ~caz~ baz '
+            ], [
+                'template' => '{{#if foo~}} bar {{~^~}} baz {{~/if}}',
+                'data' => [],
+                'enabled' => 'baz',
+                'disabled' => ' bar~ ~caz~ baz '
+            ], [
+                'template' => '{{#if foo}} bar {{~^~}} baz {{/if}}',
+                'data' => [],
+                'enabled' => 'baz ',
+                'disabled' => ' bar~ ~caz~ baz '
+            ], [
+                'template' => '{{#if foo~}} bar {{~^}} baz {{~/if}}',
+                'data' => [],
+                'enabled' => ' baz',
+                'disabled' => ' bar~ ~caz~ baz '
+            ], [
+                'template' => '{{#if foo~}} bar {{~^}} baz {{/if}}',
+                'data' => [],
+                'enabled' => ' baz ',
+                'disabled' => ' bar~ ~caz~ baz '
+            ],*/ [
+                'template' => '{{#if foo~}} bar {{~else~}} baz {{~/if}}',
+                'data' => [],
+                'enabled' => 'baz',
+                'disabled' => ''
+            ], /* [
+                'template' => "\n\n{{~#if foo~}} \n\nbar \n\n{{~^~}} \n\nbaz \n\n{{~/if~}}\n\n",
+                'data' => [],
+                'enabled' => 'baz',
+                'disabled' => ''
+            ], */ [
+                'template' => 'foo {{~> dude~}} ',
+                'data' => [],
+                'partials' => [
+                    'dude' => 'bar',
+                    'dude~' => 'caz~'
+                ],
+                'enabled' => 'foobar',
+                'disabled' => 'foo caz~ '
+            ], [
+                'template' => 'foo {{> dude~}} ',
+                'data' => [],
+                'partials' => [
+                    'dude' => 'bar',
+                    'dude~' => 'caz~'
+                ],
+                'enabled' => 'foo bar',
+                'disabled' => 'foo caz~ '
+            ], [
+                'template' => 'foo {{> dude}} ',
+                'data' => [],
+                'partials' => [
+                    'dude' => 'bar',
+                ],
+                'enabled' => 'foo bar ',
+                'disabled' => 'foo bar '
+            ], [
+                'template' => "foo\n {{~> dude}} ",
+                'data' => [],
+                'partials' => [
+                    'dude' => 'bar',
+                ],
+                'enabled' => 'foobar',
+                'disabled' => "foo\nbar"
+            ], [
+                'template' => ' {{~foo~}} {{foo}} {{foo}} ',
+                'data' => ['foo' => 'bar', '~foo~' => '~bar~'],
+                'enabled' => 'barbar bar ',
+                'disabled' => ' ~bar~ bar bar '
+            ]
+        ];
+
+        // Fan out each of the data cases into two cases: (1) for when the option is enabled and (2) when it's disabled.
+        $allCases = [];
+        foreach ($cases as $case) {
+            // Test names in PHPUnit shouldn't be multiple lines so replace the newline characters
+            $name = str_replace("\n", '\n', $case['template']);
+
+            $partials = [];
+            if (isset($case['partials'])) {
+                $partials = $case['partials'];
+            }
+
+            // Add the case when the option is disabled
+            $allCases['not enabled: ' . $name] = [
+                false,
+                $case['template'],
+                $case['data'],
+                $partials,
+                $case['disabled'],
+            ];
+
+            // Add the case when the option is enabled
+            $allCases['enabled: ' . $name] = [
+                true,
+                $case['template'],
+                $case['data'],
+                $partials,
+                $case['enabled'],
+            ];
+        }
+        return $allCases;
+    }
+}


### PR DESCRIPTION
In Handlebars, the whitespace control character (~) can be used to remove whitespace from before or after Handlebars, allowing more finer control to of the template. This PR implements the whitespace control as the option `enableWhitespaceControl` that is disabled by default. Backwards compatibility was kept except for cases noted below.

See `tests/Handlebars/WhitespaceTest.php` for examples of how whitespace control characters work.

**Backwards compatibility notes**:
* The fundamental principle was to preserve the use of the "~" character as part of the variable, section name, helper name or arguments whenever `enableWhitespaceControl` was not enabled. This attempts to recreate what was happening before this change. For example, when `enableWhitespaceControl` is not enabled, passing `{{~message}}` would look for the variable `~message` in the context, which is similar to previous functionality (whereas if enabled, `message` would be the variable name).
* Some parts of whitespace control are incompatible with the previous implementation, like whitespace control before partials (`>`) and helpers (`#`). In these cases, the previous implementation would fail to parse however they will now parse correctly but the whitespace control would be ignored. 
    For example, given the template ` {{~#if fruit}}delicious{{/if}}` and data of `{fruit => apple}`
    - the previous implementation would fail to parse with a LogicException "Unexpected closing tag: /if"
    - the current implementation and `enableWhitespaceControl` not enabled will silently ignore the whitespace character and output ` delicious` (note the extra whitespace before)
    - the current implementation and `enableWhitespaceControl` is enabled will work as expected and output `delicious` (note the whitespace is removed before)

Due to the above, it's not recommended to change `enableWhitespaceControl` from `true` to `false` (eg. once set to `true` it's best to stay at `true`).
