### PR TITLE
Add ability to post process an expression result

### DIFF
--- a/src/Handlebars/Handlebars.php
+++ b/src/Handlebars/Handlebars.php
@@ -86,6 +86,11 @@ class Handlebars
         'UTF-8'
     );
 
+    /**
+     * @var callable postprocess function to use
+     */
+    private $postprocess;
+
     private $aliases = array();
 
     /**
@@ -140,6 +145,15 @@ class Handlebars
                 $options['escapeArgs'] = array($options['escapeArgs']);
             }
             $this->escapeArgs = $options['escapeArgs'];
+        }
+
+        if (isset($options['postprocess'])) {
+            if (!is_callable($options['postprocess'])) {
+                throw new InvalidArgumentException(
+                    'Handlebars Constructor "postprocess" option must be callable'
+                );
+            }
+            $this->postprocess = $options['postprocess'];
         }
 
         if (isset($options['partials_alias'])
@@ -379,6 +393,32 @@ class Handlebars
         $this->escapeArgs = $escapeArgs;
     }
 
+    /**
+     * Get current postprocess function
+     *
+     * @return callable
+     */
+    public function getPostprocess()
+    {
+        return $this->postprocess;
+    }
+
+    /**
+     * Set current postprocess function
+     *
+     * @param callable $postprocess function
+     * @throws \InvalidArgumentException
+     * @return void
+     */
+    public function setPostprocess($postprocess)
+    {
+        if (!is_callable($postprocess)) {
+            throw new InvalidArgumentException(
+                'Postprocess function must be a callable'
+            );
+        }
+        $this->postprocess = $postprocess;
+    }
 
     /**
      * Set the Handlebars Tokenizer instance.

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -145,7 +145,7 @@ class Template
                 $newStack = isset($current[Tokenizer::NODES])
                     ? $current[Tokenizer::NODES] : [];
                 array_push($this->stack, [0, $newStack, false]);
-                $buffer .= $this->section($context, $current);
+                $buffer .= $this->postprocess($this->section($context, $current));
                 array_pop($this->stack);
                 break;
             case Tokenizer::T_INVERTED :
@@ -164,10 +164,10 @@ class Template
                 break;
             case Tokenizer::T_UNESCAPED:
             case Tokenizer::T_UNESCAPED_2:
-                $buffer .= $this->variables($context, $current, false);
+                $buffer .= $this->postprocess($this->variables($context, $current, false));
                 break;
             case Tokenizer::T_ESCAPED:
-                $buffer .= $this->variables($context, $current, true);
+                $buffer .= $this->postprocess($this->variables($context, $current, true));
                 break;
             case Tokenizer::T_TEXT:
                 $buffer .= $current[Tokenizer::VALUE];
@@ -376,14 +376,26 @@ class Template
             );
         }
 
-        if ($this->handlebars->getPostprocess()) {
-            $value = call_user_func(
-                $this->handlebars->getPostprocess(),
-                $value
-            );
+        return $value;
+    }
+
+    /**
+     * Post process value
+     *
+     * @param string $value input value
+     *
+     * @return string postprocess result of value
+     */
+    private function postprocess($value)
+    {
+        if (!$this->handlebars->getPostprocess()) {
+            return $value;
         }
 
-        return $value;
+        return call_user_func(
+            $this->handlebars->getPostprocess(),
+            $value
+        );
     }
 
     public function __clone()

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -376,6 +376,13 @@ class Template
             );
         }
 
+        if ($this->handlebars->getPostprocess()) {
+            $value = call_user_func(
+                $this->handlebars->getPostprocess(),
+                $value
+            );
+        }
+
         return $value;
     }
 


### PR DESCRIPTION
Allow the dev to supply a function to post process an expression result
```
$postprocessFn = function ($value) {
  return $value ?: "EMPTY";
};

$handlebars = new Handlebars(['postprocess' => $postprocessFn]);

$handlebars->render('Hello {{name.first}}', ['name' => ['first' => null]]);
==> "Hello EMPTY" 

```
Expressions like this will get post processed when a post process function is supplied: 
- `{{name.first}}`
- `{{#upper name.first}}`
