### PR TITLE
fix delimiters trim

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -98,7 +98,7 @@ class Tokenizer
 
         $this->reset();
 
-        if ($delimiters = trim($delimiters)) {
+        if ($delimiters !== null && $delimiters = trim($delimiters)) {
             list($otag, $ctag) = explode(' ', $delimiters);
             $this->otag = $otag;
             $this->ctag = $ctag;


### PR DESCRIPTION
<b>Deprecated</b>:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in <b>/var/www/html/vendor/salesforce/handlebars-php/src/Handlebars/Tokenizer.php</b> on line <b>101</b><br />

error happens on php 8.1.5