### PR TITLE
Fix PHP 8.1 warning about trim on null

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -98,7 +98,7 @@ class Tokenizer
 
         $this->reset();
 
-        if ($delimiters = trim($delimiters)) {
+        if ($delimiters !== null && $delimiters = trim($delimiters)) {
             list($otag, $ctag) = explode(' ', $delimiters);
             $this->otag = $otag;
             $this->ctag = $ctag;


### PR DESCRIPTION
Same as proposed by [Rangychil](https://github.com/Rangychil) but for me the CLA worked in the past...