### PR TITLE
trim(null) no longer valid in php8

### DIFF
--- a/src/Handlebars/Tokenizer.php
+++ b/src/Handlebars/Tokenizer.php
@@ -98,6 +98,11 @@ class Tokenizer
 
         $this->reset();
 
+        // Coerce NULL to empty string before passing to trim().
+        if ($delimiters === null) {
+            $delimiters = '';
+        }
+
         if ($delimiters = trim($delimiters)) {
             list($otag, $ctag) = explode(' ', $delimiters);
             $this->otag = $otag;


### PR DESCRIPTION
Fixes php8.x issue where calling `trim(null)` is no longer valid.  

In php7.x `trim(null)` evaluates to `''` (empty string) so this should provide a backwards/forwards compatible fix.