### PR TITLE
Preserve numeric keys on #each helper

### DIFF
--- a/src/Handlebars/Helpers.php
+++ b/src/Handlebars/Helpers.php
@@ -299,7 +299,7 @@ class Helpers
         $tmp = $context->get($keyname);
 
         if (is_array($tmp) || $tmp instanceof Traversable) {
-            $tmp = array_slice($tmp, $slice_start ?? 0, $slice_end);
+            $tmp = array_slice($tmp, $slice_start ?? 0, $slice_end, true);
             $buffer = '';
             $islist = array_values($tmp) === $tmp;
 

--- a/tests/Handlebars/HandlebarsTest.php
+++ b/tests/Handlebars/HandlebarsTest.php
@@ -367,6 +367,12 @@ class HandlebarsTest extends PHPUnit\Framework\TestCase
                 'outputNotEnabled' => 'applebananacarrotzucchini',
                 'outputEnabled' => ''
             ],
+            [
+                'src' => '{{#each data}}{{@key}}{{/each}}',
+                'data' => ['data' => ['fruit' => 'apple', '19' => 'banana', 'true' => 'carrot']],
+                'outputNotEnabled' => 'fruit19true',
+                'outputEnabled' => 'fruit19true',
+            ],
         ];
 
         // Build out a test case for when the enableDataVariables feature is enabled and when it's not


### PR DESCRIPTION
Preserving numeric keys on #each helper, to maintain `@key` data variable functioning on int arrays

Assuming an array should be printed out like (`enableDataVariables` set to `true`):
```
{{#each arr}}
    {{ @key }}:   {{ this }}
{{/each}}
```
which was defined as
```
$arr = [
    '19' => 5
];
```
(key can be any integer)
The resulting `@key` variable was always printed as `0`. `array_slice`in the helper function caused numeric keys to be set to `0` while maintaing string keys correctly. The pull request is enabling explicit key preserving, to fix such issue.