### PR TITLE
Fix incorrect PHPDoc type and remove unused property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,24 @@
 name: PHPUnit
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
-
+    name: Run tests on ${{ matrix.php }}
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php: [ '7.4', '8.0', '8.1', '8.2' ]
+
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
 
       - name: Composer Install
         run: composer install

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="tests/bootstrap.php" colors="true">
-    <testsuites>
-        <testsuite name="Handlebars Test suite">
-            <directory>tests/Handlebars/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Handlebars Test suite">
+      <directory>tests/Handlebars/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Handlebars/Template.php
+++ b/src/Handlebars/Template.php
@@ -27,7 +27,6 @@ class Template
      */
     protected $handlebars;
 
-
     protected $tree = [];
 
     protected $source = '';
@@ -36,7 +35,6 @@ class Template
      * @var array Run stack
      */
     private $stack = [];
-    private $_stack = [];
 
     /**
      * Handlebars template constructor
@@ -51,7 +49,6 @@ class Template
         $this->tree = $tree;
         $this->source = $source;
         array_push($this->stack, [0, $this->getTree(), false]);
-
     }
 
     /**
@@ -87,14 +84,12 @@ class Template
     /**
      * set stop token for render and discard method
      *
-     * @param string $token token to set as stop token or false to remove
+     * @param string|false $token token to set as stop token or false to remove
      *
      * @return void
      */
-
     public function setStopToken($token)
     {
-        $this->_stack = $this->stack;
         $topStack = array_pop($this->stack);
         $topStack[2] = $token;
         array_push($this->stack, $topStack);
@@ -103,9 +98,8 @@ class Template
     /**
      * get current stop token
      *
-     * @return string|bool
+     * @return string|false
      */
-
     public function getStopToken()
     {
         return end($this->stack)[2];
@@ -191,8 +185,6 @@ class Template
 
     /**
      * Discard top tree
-     *
-     * @param mixed $context current context
      *
      * @return string
      */


### PR DESCRIPTION
Avoids error when using the library in a codebase with static analysis.

Also updated PHPUnit configuration to fix deprecated schema warning.